### PR TITLE
Preserve fractional part of timestamp

### DIFF
--- a/pg.el
+++ b/pg.el
@@ -2341,7 +2341,7 @@ Uses text encoding ENCODING."
             (day     (string-to-number (match-string 3 str)))
             (hours   (string-to-number (match-string 4 str)))
             (minutes (string-to-number (match-string 5 str)))
-            (seconds (round (string-to-number (match-string 6 str))))
+            (seconds (string-to-number (match-string 6 str)))
             ;; If the timezone is not explicitly specified, use the local one
             (tz      (or (match-string 7 str) nil)))
         (encode-time (list seconds minutes hours day month year nil nil tz)))
@@ -2356,7 +2356,7 @@ Uses text encoding ENCODING."
             (day     (string-to-number (match-string 3 str)))
             (hours   (string-to-number (match-string 4 str)))
             (minutes (string-to-number (match-string 5 str)))
-            (seconds (round (string-to-number (match-string 6 str))))
+            (seconds (string-to-number (match-string 6 str)))
             ;; The timezone must be ignored even if it is specified
             (tz      nil))
         (encode-time (list seconds minutes hours day month year nil nil tz)))


### PR DESCRIPTION
While parsing timestamp strings the seconds part would be wrapped in a round call, which produced an integer value, cutting off the fractional part. We remove the round call and leave it to the output formatter to get the desired result.