### PR TITLE
Call url-unhex-string on user/password only if non-nil

### DIFF
--- a/pg.el
+++ b/pg.el
@@ -1051,9 +1051,11 @@ sslmode (partial support) and application_name."
     ;; FIXME unfortunately the url-host is being downcased by url-generic-parse-url, which is
     ;; incorrect when the hostname is specifying a local path.
     (let* ((host (url-unhex-string (url-host parsed)))
-           (user (or (url-unhex-string (url-user parsed))
+           (parsed-user (url-user parsed))
+           (parsed-password (url-password parsed))
+           (user (or (when parsed-user (url-unhex-string parsed-user))
                      (getenv "PGUSER")))
-           (password (or (url-unhex-string (url-password parsed))
+           (password (or (when parsed-password (url-unhex-string parsed-password))
                          (getenv "PGPASSWORD")))
            (port (or (url-portspec parsed)
                      (getenv "PGPORT")


### PR DESCRIPTION
Since url-unhex-string always returns at least the empty string, it would be impossible to omit user or password from the URL, thus effectively disallowing the use of environment variables.

Fixes #10.