### PR TITLE
Add lambda password support for secure auth-source integration

### DIFF
--- a/pg.el
+++ b/pg.el
@@ -752,9 +752,12 @@ Uses database DBNAME, user USER and password PASSWORD."
           ;; AUTH_REQ_CLEARTEXT_PASSWORD
           (3
           ;; send a PasswordMessage
-          (pg-send-char con ?p)
-          (pg-send-uint con (+ 5 (length password)) 4)
-          (pg-send-string con password)
+          (let ((actual-password (if (functionp password)
+                                    (funcall password)
+                                  password)))
+            (pg-send-char con ?p)
+            (pg-send-uint con (+ 5 (length actual-password)) 4)
+            (pg-send-string con actual-password))
           (pg-flush con))
 
          ;; AUTH_REQ_CRYPT
@@ -3343,8 +3346,11 @@ Respects floating-point infinities and NaN."
 (defun pg-do-md5-authentication (con user password)
   "Attempt MD5 authentication with PostgreSQL database over connection CON.
 Authenticate as USER with PASSWORD."
-  (let* ((salt (pg-read-chars con 4))
-         (pwdhash (md5 (concat password user)))
+  (let* ((actual-password (if (functionp password)
+                             (funcall password)
+                           password))
+         (salt (pg-read-chars con 4))
+         (pwdhash (md5 (concat actual-password user)))
          (hash (concat "md5" (md5 (concat pwdhash salt)))))
     (pg-send-char con ?p)
     (pg-send-uint con (+ 5 (length hash)) 4)
@@ -3512,13 +3518,16 @@ Authenticate as USER with PASSWORD."
 (defun pg-do-sasl-authentication (con user password)
   "Attempt SASL authentication with PostgreSQL over connection CON.
 Authenticate as USER with PASSWORD."
-  (let ((mechanisms (list)))
+  (let ((actual-password (if (functionp password)
+                            (funcall password)
+                          password))
+        (mechanisms (list)))
     ;; read server's list of preferered authentication mechanisms
     (cl-loop for mech = (pg-read-string con 4096)
              while (not (zerop (length mech)))
              do (push mech mechanisms))
     (if (member "SCRAM-SHA-256" mechanisms)
-        (pg-do-scram-sha256-authentication con user password)
+        (pg-do-scram-sha256-authentication con user actual-password)
       (let ((msg (format "Can't handle any of SASL mechanisms %s" mechanisms)))
         (signal 'pg-protocol-error (list msg))))))
 


### PR DESCRIPTION
## Summary

This PR adds support for passing lambda functions as passwords to `pg-connect`, enabling secure integration with Emacs auth-source without storing passwords in memory.

## Motivation

Currently, pg-el requires passwords to be strings, which means they must be retrieved and stored in memory before connecting. This poses security concerns as passwords remain in Emacs' memory even after use. By supporting lambda functions, passwords can be fetched on-demand and immediately discarded.

## Changes

- Modified password handling in `pg-connect` and authentication functions to accept both strings and functions
- When a function is provided as password, it's called to retrieve the actual password only when needed
- Maintains backward compatibility - existing code using string passwords continues to work

## Use Case: pgx-mode

This feature enables packages like [pgx-mode](https://github.com/Kaylebor/pgx-mode) to integrate with auth-source securely:

```elisp
(defun pgx-auth-source-get-password (host user port)
  "Returns a lambda that fetches password from auth-source when called."
  (lambda ()
    (let* ((auth (car (auth-source-search
                      :host host
                      :user user  
                      :port port
                      :require '(:secret)
                      :max 1)))
           (secret (plist-get auth :secret)))
      (when secret
        (if (functionp secret)
            (funcall secret)
          secret)))))

;; Usage in connection
(let ((password (if (string= server "localhost")
                    ""  ; Empty for localhost
                  (pgx-auth-source-get-password server user port))))
  (pg-connect database user password server port tls-options))
```

## Benefits

1. **Enhanced Security**: Passwords are never stored in variables, reducing memory exposure
2. **Auth-source Integration**: Seamlessly works with Emacs' built-in secure credential storage
3. **Backward Compatible**: Existing code continues to work without modifications
4. **Minimal Changes**: Small, focused modification that doesn't affect core functionality

## Testing

Tested with:
- PostgreSQL 14+ with various authentication methods (md5, scram-sha-256)
- Both localhost and remote connections
- SSL/TLS connections with various sslmode settings
- Integration with [pgx-mode](https://github.com/Kaylebor/pgx-mode) package